### PR TITLE
Delete credentials.txt

### DIFF
--- a/credentials.txt
+++ b/credentials.txt
@@ -1,2 +1,0 @@
-User name,Password,Access key ID,Secret access key,Console login link
-annis-python,,Key, Password,https://023385150594.signin.aws.amazon.com/console


### PR DESCRIPTION
For security reason, you can't leave your credential information in public